### PR TITLE
Fix TypeError: not all arguments converted during string formatting

### DIFF
--- a/pandoc_fignos.py
+++ b/pandoc_fignos.py
@@ -446,7 +446,7 @@ def process(meta):
                 msg = textwrap.dedent("""
                           pandoc-fignos: caption separator must be one of
                           none, colon, period, space, quad, or newline.
-                      """ % name)
+                      """)
                 STDERR.write(msg)
                 continue
             separator_changed = separator != old_separator


### PR DESCRIPTION
The error was happening when an invalid value of `fignos-caption-separator` was specified.

Or should I try to somehow include `name` in the error message?